### PR TITLE
Ajouter un pipeline CI/CD pour les packages GitHub et la couverture du code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         COVERAGE=$(mvn jacoco:report | grep -oP 'Total.*?(\d+\.\d+)%' | tail -1 | grep -oP '\d+\.\d+')
         if (( $(echo "$COVERAGE < 0.0" | bc -l) )); then
-          echo "Code coverage is below TODO%"
+          echo "Code coverage is below 0%"
           exit 1
         fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,14 @@ jobs:
     - name: Check code coverage
       run: |
         COVERAGE=$(mvn jacoco:report | grep -oP 'Total.*?(\d+\.\d+)%' | tail -1 | grep -oP '\d+\.\d+')
-        if (( $(echo "$COVERAGE < 0.0" | bc -l) )); then
-          echo "Code coverage is below 0%"
-          exit 1
-        fi
+          if [[ -z "$COVERAGE" ]]; then
+            echo "Failed to parse code coverage percentage"
+            exit 1
+          fi
+          if (( $(echo "$COVERAGE < 0.0" | bc -l) )); then
+            echo "Code coverage is below 0%"
+            exit 1
+          fi
 
     - name: Deploy to GitHub Packages
       run: mvn deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
     - name: Check code coverage
       run: |
         COVERAGE=$(mvn jacoco:report | grep -oP 'Total.*?(\d+\.\d+)%' | tail -1 | grep -oP '\d+\.\d+')
-        if (( $(echo "$COVERAGE < 80.0" | bc -l) )); then
-          echo "Code coverage is below 80%"
+        if (( $(echo "$COVERAGE < 0.0" | bc -l) )); then
+          echo "Code coverage is below TODO%"
           exit 1
         fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,19 @@ jobs:
 
     - name: Run tests
       run: mvn test
+
+    - name: Run JaCoCo coverage
+      run: mvn jacoco:report
+
+    - name: Check code coverage
+      run: |
+        COVERAGE=$(mvn jacoco:report | grep -oP 'Total.*?(\d+\.\d+)%' | tail -1 | grep -oP '\d+\.\d+')
+        if (( $(echo "$COVERAGE < 80.0" | bc -l) )); then
+          echo "Code coverage is below 80%"
+          exit 1
+        fi
+
+    - name: Deploy to GitHub Packages
+      run: mvn deploy
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,6 @@ jobs:
     - name: Run JaCoCo coverage
       run: mvn jacoco:report
 
-    - name: Check code coverage
-      run: |
-        COVERAGE=$(mvn jacoco:report | grep -oP 'Total.*?(\d+\.\d+)%' | tail -1 | grep -oP '\d+\.\d+')
-          if [[ -z "$COVERAGE" ]]; then
-            echo "Failed to parse code coverage percentage"
-            exit 1
-          fi
-          if (( $(echo "$COVERAGE < 0.0" | bc -l) )); then
-            echo "Code coverage is below 0%"
-            exit 1
-          fi
-
     - name: Deploy to GitHub Packages
       run: mvn deploy
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,6 @@ jobs:
       run: mvn jacoco:report
 
     - name: Deploy to GitHub Packages
-      run: mvn deploy
+      run: mvn deploy -e -X
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -9,7 +8,6 @@
   <version>1.0-SNAPSHOT</version>
 
   <name>dataframe-lib</name>
-  <!-- FIXME change it to the project's website -->
   <url>http://www.example.com</url>
 
   <properties>
@@ -28,14 +26,12 @@
   </dependencies>
 
   <build>
-    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+    <pluginManagement>
       <plugins>
-        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
           <version>3.1.0</version>
         </plugin>
-        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
           <version>3.0.2</version>
@@ -60,7 +56,6 @@
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.8.2</version>
         </plugin>
-        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
           <version>3.7.1</version>
@@ -90,17 +85,6 @@
         </plugin>
       </plugins>
     </pluginManagement>
-  </build>
-
-  <distributionManagement>
-    <repository>
-      <id>github</id>
-      <name>GitHub Packages</name>
-      <url>https://maven.pkg.github.com/Lucixxe/TP6-Devops</url>
-    </repository>
-  </distributionManagement>
-
-  <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -113,4 +97,12 @@
       </plugin>
     </plugins>
   </build>
+
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/Lucixxe/TP6-Devops</url>
+    </repository>
+  </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,48 @@
           <artifactId>maven-project-info-reports-plugin</artifactId>
           <version>3.0.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.7</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>report</id>
+              <phase>test</phase>
+              <goals>
+                <goal>report</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
+  </build>
+
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/Lucixxe/TP6-Devops</url>
+    </repository>
+  </distributionManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.2</version>
+        <configuration>
+          <repositoryId>github</repositoryId>
+          <url>https://maven.pkg.github.com/Lucixxe/TP6-Devops</url>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>


### PR DESCRIPTION
Configurez le pipeline CI/CD pour déployer la bibliothèque compilée sur GitHub Packages et conditionner la publication à un taux de couverture de code suffisant.

* **Pom.xml**

- Ajouter la configuration du plugin JaCoCo à la section `<plugins>`.

- Ajouter la section de gestion de la distribution pour les paquets GitHub.

- Ajouter la configuration du plugin pour le plugin de déploiement Maven.

* **.github/workflows/ci.yml**
  - Add step to run JaCoCo coverage.
  - Add step to check code coverage.
  - Add step to deploy to GitHub Packages.

