### PR TITLE
Ajouter un badge au flux de travail de test CI Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Une bibliothèque Java d'analyse de données, inspirée de Pandas.
 
 ## CI/CD Status
 [![CI/CD Maven Deploy](https://github.com/Lucixxe/TP6-Devops/actions/workflows/deploy.yml/badge.svg?branch=zodecky%2Ffeature%2Fadd-cd)](https://github.com/Lucixxe/TP6-Devops/actions/workflows/deploy.yml)
+[![CI Maven Test](https://github.com/Lucixxe/TP6-Devops/actions/workflows/autotest.yml/badge.svg?branch=main)](https://github.com/Lucixxe/TP6-Devops/actions/workflows/autotest.yml)
 
 ## Auteur
 Ilian Benaoudia


### PR DESCRIPTION
Ajouter un badge pour le workflow de test CI Maven au fichier `README.md`.

* Ajouter un badge sous la section « CI/CD Status ».
* Lier le badge au fichier `.github/workflows/autotest.yml`.