### PR TITLE
Appliquer une couverture de code de 60 % dans le pipeline CI/CD

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -5,9 +5,9 @@ on:
     branches:
       - main  # Trigger when a PR targets the 'main' branch
     types:
-      - opened        # Trigger when a PR is opened
-      - synchronize  # Trigger when a PR is updated (e.g., commits pushed)
-      - reopened     # Trigger when a PR is reopened
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   test:
@@ -23,11 +23,9 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
 
-    - name: Run tests with Maven
-      run: mvn test
-
-    - name: Check code coverage
-      run: mvn verify
+    - name: Build, test, and check code coverage
+      id: check-code-coverage
+      run: mvn clean verify
 
     - name: Ensure code coverage is above 60%
       if: success() && steps.check-code-coverage.outcome == 'success'

--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -26,3 +26,9 @@ jobs:
     - name: Run tests with Maven
       run: mvn test
 
+    - name: Check code coverage
+      run: mvn verify
+
+    - name: Ensure code coverage is above 60%
+      if: success() && steps.check-code-coverage.outcome == 'success'
+      run: echo "Code coverage is above 60%"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,11 @@ jobs:
     - name: Maven test
       run: mvn test
 
+    - name: Check code coverage
+      run: mvn verify
+
     - name: Build & Deploy with Maven
+      if: success() && steps.check-code-coverage.outcome == 'success'
       run: mvn deploy -s $GITHUB_WORKSPACE/.github/settings.xml
       env:
         GH_USERNAME: ${{ secrets.GH_USERNAME }}

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,10 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <minimum>0.6</minimum>
+          <failOnViolation>true</failOnViolation>
+        </configuration>
       </plugin>
 
       <!-- ✅ Déploiement Maven (CD) -->

--- a/pom.xml
+++ b/pom.xml
@@ -62,11 +62,13 @@
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.7</version>
         <executions>
+          <!-- Attach JaCoCo agent -->
           <execution>
             <goals>
               <goal>prepare-agent</goal>
             </goals>
           </execution>
+          <!-- Generate the coverage report -->
           <execution>
             <id>report</id>
             <phase>test</phase>
@@ -74,11 +76,29 @@
               <goal>report</goal>
             </goals>
           </execution>
+          <!-- Check if the coverage meets the minimum threshold -->
+          <execution>
+            <id>check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <rule>
+                  <element>PACKAGE</element>
+                  <limits>
+                    <limit>
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.60</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
         </executions>
-        <configuration>
-          <minimum>0.6</minimum>
-          <failOnViolation>true</failOnViolation>
-        </configuration>
       </plugin>
 
       <!-- ✅ Déploiement Maven (CD) -->


### PR DESCRIPTION
Mettre en place une exigence de couverture de code de 60 % dans le pipeline CI/CD.

*   **pom.xml**
    *   Ajouter un bloc `<configuration>` à `jacoco-maven-plugin` pour définir `<minimum>` sur `0.6`.
    *   Ajouter `<failOnViolation>` à `true` dans le bloc `<configuration>` de `jacoco-maven-plugin`.
*   **.github/workflows/deploy.yml**
    *   Ajouter une nouvelle étape avant `Build & Deploy with Maven` pour vérifier la couverture de code.
    *   Utiliser la commande `mvn verify` pour exécuter les tests et générer le rapport de couverture de code.
    *   Ajouter une condition à l'étape `Build & Deploy with Maven` pour vérifier si la couverture de code est supérieure à 60 %.
*   **.github/workflows/autotest.yml**
    *   Ajouter une nouvelle étape après `Run tests with Maven` pour vérifier la couverture de code.
    *   Utiliser la commande `mvn verify` pour exécuter les tests et générer le rapport de couverture de code.
    *   Ajouter une condition à l'étape `Run tests with Maven` pour vérifier si la couverture de code est supérieure à 60 %.